### PR TITLE
Check for NULL window before tapping

### DIFF
--- a/lib/touch.js
+++ b/lib/touch.js
@@ -186,12 +186,18 @@ const Injector = ObjC.registerClass({
 });
 
 function tap(view, x, y) {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
+    const window = view.window();
+    if (window === null) {
+      reject(new Error('Cannot tap on NULL window'));
+      return;
+    }
+
     const point = view.convertPoint_toView_([x, y], NULL);
 
     const injector = Injector.alloc().init();
     const priv = ObjC.getBoundData(injector);
-    priv.window = view.window();
+    priv.window = window;
     priv.pending.push(point, CGPointZero);
     priv.onComplete = function () {
       injector.release();


### PR DESCRIPTION
- and propagate the error to the caller