### PR TITLE
Avoid use after free on kept-alive views

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -27,11 +27,14 @@ function keepViewsAlive() {
     originalWillMoveToWindow(handle, selector, window);
 
     const key = handle.toString();
-    const node = activeInstances[key];
+    const nodes = activeInstances[key];
 
-    if (window.isNull() && node !== undefined) {
-      const view = node.instance;
-      node.instance = null;
+    if (window.isNull() && nodes !== undefined) {
+      let view = null;
+      for (const node of nodes) {
+        view = node.instance;
+        node.instance = null;
+      }
       delete activeInstances[key];
       view.release();
     }
@@ -44,7 +47,9 @@ function UINode(view) {
   const activeKey = view.handle.toString();
   if (!(activeKey in activeInstances)) {
     view.retain();
-    activeInstances[activeKey] = this;
+    activeInstances[activeKey] = new Set([this]);
+  } else {
+    activeInstances[activeKey].add(this);
   }
 
   if (UIWebViewClass === null) {
@@ -182,6 +187,22 @@ UINode.prototype = {
         touch.tap(view, x, y).then(resolve, reject);
       })
     });
+  },
+  dispose() {
+    const view = this.instance;
+    if (view === null) {
+      return;
+    }
+    const activeKey = view.handle.toString();
+    const nodes = activeInstances[activeKey];
+    if (nodes !== undefined) {
+      nodes.delete(this);
+      if (nodes.size === 0) {
+        delete activeInstances[activeKey];
+        view.release();
+      }
+    }
+    this.children.forEach(child => child.dispose());
   }
 };
 


### PR DESCRIPTION
- save all nodes related to each view in a set
- set to `null` the instance of every node when releasing the underlying view
- add `dispose()` on the node object, to avoid keeping them alive forever if the view is never released