### PR TITLE
Add support for iOS 14.x

### DIFF
--- a/lib/touch.js
+++ b/lib/touch.js
@@ -209,7 +209,7 @@ function tap(view, x, y) {
 
 function setIsTap (touch, isTap) {
   const flags = touch.$ivars['_touchFlags'];
-  const newFlags = [...flags]
+  const newFlags = [...flags];
   if (isTap) {
     newFlags[0] |= UITOUCH_FLAG_IS_TAP;
   } else {

--- a/lib/touch.js
+++ b/lib/touch.js
@@ -220,7 +220,7 @@ function setIsTap (touch, isTap) {
 
 function setIsFirstTouchForView (touch, isFirst) {
   const flags = touch.$ivars['_touchFlags'];
-  const newFlags = [...flags]
+  const newFlags = [...flags];
   if (isFirst) {
     newFlags[0] |= UITOUCH_FLAG_IS_FIRST_TOUCH_FOR_VIEW;
   } else {

--- a/lib/touch.js
+++ b/lib/touch.js
@@ -10,6 +10,9 @@ const UITouchPhaseStationary = 2;
 const UITouchPhaseEnded = 3;
 const UITouchPhaseCancelled = 4;
 
+const UITOUCH_FLAG_IS_FIRST_TOUCH_FOR_VIEW = 1;
+const UITOUCH_FLAG_IS_TAP = 2;
+
 const CGFloat = (Process.pointerSize === 4) ? 'float' : 'double';
 const CGPoint = [CGFloat, CGFloat];
 const CGPointEqualToPoint = new NativeFunction(
@@ -102,13 +105,13 @@ const Injector = ObjC.registerClass({
           touch = UITouch.alloc().init();
           priv.touch = touch;
           touch.setTapCount_(1);
-          touch.setIsTap_(true);
+          setIsTap(touch, true);
           phase = UITouchPhaseBegan;
           touch.setPhase_(phase);
           touch.setWindow_(priv.window);
           touch['- _setLocationInWindow:resetPrevious:'].call(touch, point, true);
           touch.setView_(priv.window.hitTest_withEvent_(point, NULL));
-          touch['- _setIsFirstTouchForView:'].call(touch, true);
+          setIsFirstTouchForView(touch, true);
         } else {
           touch = priv.touch;
 
@@ -202,6 +205,28 @@ function tap(view, x, y) {
       resolve();
     };
   });
+}
+
+function setIsTap (touch, isTap) {
+  const flags = touch.$ivars['_touchFlags'];
+  const newFlags = [...flags]
+  if (isTap) {
+    newFlags[0] |= UITOUCH_FLAG_IS_TAP;
+  } else {
+    newFlags[0] &= ~UITOUCH_FLAG_IS_TAP;
+  }
+  touch.$ivars['_touchFlags'] = newFlags;
+}
+
+function setIsFirstTouchForView (touch, isFirst) {
+  const flags = touch.$ivars['_touchFlags'];
+  const newFlags = [...flags]
+  if (isFirst) {
+    newFlags[0] |= UITOUCH_FLAG_IS_FIRST_TOUCH_FOR_VIEW;
+  } else {
+    newFlags[0] &= ~UITOUCH_FLAG_IS_FIRST_TOUCH_FOR_VIEW;
+  }
+  touch.$ivars['_touchFlags'] = newFlags;
 }
 
 module.exports = {


### PR DESCRIPTION
By reconstructing the functionality of `-[UITouch setIsTap]` and `-[UITouch _setIsFirstTouchForView:]` (which are gone from Objective-C's runtime thanks to the new “direct methods” feature) via direct manipulation of the `_touchFlags` ivar.