### PR TITLE
Check return types besides method existence

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -99,7 +99,7 @@ UINode.prototype = {
       if (instance === null) {
         return false;
       }
-      if ('enabled' in instance) {
+      if ('enabled' in instance && instance.enabled.returnType === 'bool') {
         this._enabled = !!instance.enabled();
       } else {
         this._enabled = true;
@@ -113,16 +113,16 @@ UINode.prototype = {
       if (instance === null) {
         return '';
       }
-      if ('accessibilityLabel' in instance) {
+      if ('accessibilityLabel' in instance && instance.accessibilityLabel.returnType === 'pointer') {
         const accLabel = instance.accessibilityLabel();
         if (accLabel !== null) {
           this._label = accLabel.toString();
         }
       }
       if (this._label === null) {
-        if ('placeholder' in instance) {
+        if ('placeholder' in instance && instance.placeholder.returnType === 'pointer') {
           this._label = readStringProperty(instance.placeholder());
-        } else if ('text' in instance) {
+        } else if ('text' in instance && instance.text.returnType === 'pointer') {
           this._label = readStringProperty(instance.text());
         } else {
           this._label = '';


### PR DESCRIPTION
This is needed to guard against apps which mess with the Objective-C runtime to have default empty implementations for all requested methods even if not present.

/cc @hexploitable